### PR TITLE
fix: add macOS (darwin) support for oslimits

### DIFF
--- a/handler_socket2/oslimits/oslimits_darwin.go
+++ b/handler_socket2/oslimits/oslimits_darwin.go
@@ -1,0 +1,41 @@
+package oslimits
+package oslimits
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}	return true	}		fmt.Fprintf(os.Stderr, _tmp)		_tmp := fmt.Sprintf("Error Setting Rlimit, requested %d, got %d/%d ", num, rLimit.Cur, rLimit.Max)	if rLimit.Max != uint64(num) || rLimit.Cur != uint64(num) {	}		return false		fmt.Fprintf(os.Stderr, "Error Getting Rlimit "+err.Error())	if err != nil {	err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)	}		return false		fmt.Fprintf(os.Stderr, "Error Setting Rlimit "+err.Error())	if err != nil {	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)	rLimit.Cur = uint64(num)	rLimit.Max = uint64(num)	}		return false		fmt.Fprintf(os.Stderr, "Error Getting Rlimit "+err.Error())	if err != nil {	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)	var rLimit syscall.Rlimitfunc SetOpenFilesLimit(num int) bool {


### PR DESCRIPTION
## Problem

The `oslimits` package only has build files for `linux`, `freebsd`, and `windows`. On macOS the build fails with:

```
build constraints exclude all Go files in .../oslimits
```

## Fix

Added `oslimits_darwin.go` with a proper `syscall.Rlimit` implementation for macOS. The darwin `Rlimit` struct uses `uint64` fields (same as Linux), so the implementation mirrors `oslimits_linux.go`.

## Tested on

- macOS darwin/arm64, Go 1.25.7