### PR TITLE
fix: correct oslimits_darwin.go syntax errors

### DIFF
--- a/handler_socket2/oslimits/oslimits_darwin.go
+++ b/handler_socket2/oslimits/oslimits_darwin.go
@@ -1,5 +1,4 @@
 package oslimits
-package oslimits
 
 import (
 	"fmt"
@@ -7,35 +6,34 @@ import (
 	"syscall"
 )
 
+func SetOpenFilesLimit(num int) bool {
 
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error Getting Rlimit "+err.Error())
+		return false
+	}
 
+	rLimit.Max = uint64(num)
+	rLimit.Cur = uint64(num)
 
+	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error Setting Rlimit "+err.Error())
+		return false
+	}
 
+	err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error Getting Rlimit "+err.Error())
+		return false
+	}
 
+	if rLimit.Max != uint64(num) || rLimit.Cur != uint64(num) {
+		_tmp := fmt.Sprintf("Error Setting Rlimit, requested %d, got %d/%d ", num, rLimit.Cur, rLimit.Max)
+		fmt.Fprintf(os.Stderr, _tmp)
+	}
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-}	return true	}		fmt.Fprintf(os.Stderr, _tmp)		_tmp := fmt.Sprintf("Error Setting Rlimit, requested %d, got %d/%d ", num, rLimit.Cur, rLimit.Max)	if rLimit.Max != uint64(num) || rLimit.Cur != uint64(num) {	}		return false		fmt.Fprintf(os.Stderr, "Error Getting Rlimit "+err.Error())	if err != nil {	err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)	}		return false		fmt.Fprintf(os.Stderr, "Error Setting Rlimit "+err.Error())	if err != nil {	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)	rLimit.Cur = uint64(num)	rLimit.Max = uint64(num)	}		return false		fmt.Fprintf(os.Stderr, "Error Getting Rlimit "+err.Error())	if err != nil {	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)	var rLimit syscall.Rlimitfunc SetOpenFilesLimit(num int) bool {
+	return true
+}


### PR DESCRIPTION
## Problem

`oslimits_darwin.go` has severe syntax errors that prevent compilation on macOS:
- Duplicate `package oslimits` declaration
- The entire function body is garbled/reversed onto a single line
- Missing newline at end of file

```
oslimits_darwin.go:2:1: syntax error: non-declaration statement outside function body
oslimits_darwin.go:4:1: syntax error: imports must appear before other declarations
oslimits_darwin.go:41:1: syntax error: non-declaration statement outside function body
```

## Fix

Reconstructed the proper `SetOpenFilesLimit` function to match the linux implementation (without the `runtime.GOOS` check, since the build constraint already handles platform selection). The file is `gofmt`-formatted and passes `go vet`.